### PR TITLE
Slight modifications to avoid unnecessary code execution possibly impacting user experience

### DIFF
--- a/BoostCountdown/BoostCountdown.cpp
+++ b/BoostCountdown/BoostCountdown.cpp
@@ -30,7 +30,7 @@ void BoostCountdown::onLoad()
 		int close = GetClosestPad(loc);
 
 		if (close != -1) {
-			ServerWrapper server = gameWrapper->GetCurrentGameState();
+			ServerWrapper server = gameWrapper->GetGameEventAsServer();
 			if (!server) { return; }
 			time.at(close) = server.GetSecondsElapsed();
 		}
@@ -48,7 +48,7 @@ void BoostCountdown::onLoad()
 }
 
 void BoostCountdown::Countdown(int padID) {
-	ServerWrapper server = gameWrapper->GetCurrentGameState();
+	ServerWrapper server = gameWrapper->GetGameEventAsServer();
 	if (!server) { return; }
 	float start = server.GetSecondsElapsed();
 	float end = start + 10.0;
@@ -75,11 +75,7 @@ int BoostCountdown::GetClosestPad(Vector loc) {
 
 void BoostCountdown::Render(CanvasWrapper canvas)
 {
-	if (gameWrapper->IsInOnlineGame())
-	{
-		return;
-	}
-	ServerWrapper server = gameWrapper->GetCurrentGameState();
+	ServerWrapper server = gameWrapper->GetGameEventAsServer();
 	if (!server) { return; }
 	CameraWrapper camera = gameWrapper->GetCamera();
 
@@ -132,10 +128,6 @@ void BoostCountdown::Render(CanvasWrapper canvas)
 
 
 bool BoostCountdown::isOnScreen(Vector camera, Vector camPos, Vector UIPos) {
-	if (gameWrapper->IsInOnlineGame())
-	{
-		return;
-	}
 	Vector vecToUI = Vector{ camPos - UIPos }.getNormalized();
 	float viewToUIAng = acos(Vector::dot(camera, vecToUI) / camera.magnitude() * vecToUI.magnitude());
 	//LOG(to_string(viewToUIAng));

--- a/BoostCountdown/BoostCountdown.cpp
+++ b/BoostCountdown/BoostCountdown.cpp
@@ -19,9 +19,9 @@ void BoostCountdown::onLoad()
 		Render(canvas);
 		});
 
-	cvarManager->registerCvar("enable", "0", "Enables the plugin", true, true, 0, true, 1, false).bindTo(enable);
-	cvarManager->registerCvar("ui_color", "#FFFF00FF", "color of background", true, false, 0, false, 0, true);
-	cvarManager->registerCvar("scale", "5", "scale of ui", true, true, 1, true, 10, true).bindTo(scale_UI);
+	cvarManager->registerCvar("boostcountdown_enable", "0", "Enables the plugin", true, true, 0, true, 1, false).bindTo(enable);
+	cvarManager->registerCvar("boostcountdown_ui_color", "#FFFF00FF", "color of background", true, false, 0, false, 0, true);
+	cvarManager->registerCvar("boostcountdown_scale", "5", "scale of ui", true, true, 1, true, 10, true).bindTo(scale_UI);
 
 	gameWrapper->HookEventWithCaller<CarWrapper>("Function TAGame.VehiclePickup_TA.OnPickUp", [this](CarWrapper caller, void* params, std::string eventName) {
 		if (!*enable) {return;}

--- a/BoostCountdown/BoostCountdown.cpp
+++ b/BoostCountdown/BoostCountdown.cpp
@@ -117,7 +117,7 @@ void BoostCountdown::Render(CanvasWrapper canvas)
 					pos.X -= textSize.X / 2;
 					pos.Y -= textSize.Y / 2;
 
-					CVarWrapper col = cvarManager->getCvar("ui_color");
+					CVarWrapper col = cvarManager->getCvar("boostcountdown_ui_color");
 					canvas.SetColor(col.getColorValue());
 
 					canvas.SetPosition(pos);

--- a/BoostCountdown/BoostCountdown.cpp
+++ b/BoostCountdown/BoostCountdown.cpp
@@ -138,7 +138,7 @@ bool BoostCountdown::isOnScreen(Vector camera, Vector camPos, Vector UIPos) {
 	}
 	Vector vecToUI = Vector{ camPos - UIPos }.getNormalized();
 	float viewToUIAng = acos(Vector::dot(camera, vecToUI) / camera.magnitude() * vecToUI.magnitude());
-	LOG(to_string(viewToUIAng));
+	//LOG(to_string(viewToUIAng));
 	if (3.1415 - viewToUIAng <= fov) {
 		return true;
 	}

--- a/BoostCountdown/BoostCountdown.cpp
+++ b/BoostCountdown/BoostCountdown.cpp
@@ -75,6 +75,10 @@ int BoostCountdown::GetClosestPad(Vector loc) {
 
 void BoostCountdown::Render(CanvasWrapper canvas)
 {
+	if (gameWrapper->IsInOnlineGame())
+	{
+		return;
+	}
 	ServerWrapper server = gameWrapper->GetCurrentGameState();
 	if (!server) { return; }
 	CameraWrapper camera = gameWrapper->GetCamera();
@@ -128,6 +132,10 @@ void BoostCountdown::Render(CanvasWrapper canvas)
 
 
 bool BoostCountdown::isOnScreen(Vector camera, Vector camPos, Vector UIPos) {
+	if (gameWrapper->IsInOnlineGame())
+	{
+		return;
+	}
 	Vector vecToUI = Vector{ camPos - UIPos }.getNormalized();
 	float viewToUIAng = acos(Vector::dot(camera, vecToUI) / camera.magnitude() * vecToUI.magnitude());
 	LOG(to_string(viewToUIAng));


### PR DESCRIPTION
Using GetCurrentGameState() also returns a ServerWrapper for online games, so a lot of the code is still executed in those games. Now, I think it doesn't work properly online, but it might result in a bunch of things getting rendered all over the screen because of some built-in BM protections. Using GetGameEventAsServer() will only return a ServerWrapper if the user is the host of the current game (so LAN or offline) which will avoid any of the code running online at all.

I've also changed the cvar names to be more plugin specific, I'm a little worried that using cvar names like these cause clashes with other plugins so I've changed them to match the format other plugins.